### PR TITLE
Add github actions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+## The problem
+
+Briefly describe the issue you are experiencing (or feature you want to see added). Tell us what you were trying to do and what happened instead. If you have any helpful screenshots or a file you tried to upload, please include them! Please also select an appropriate label (to the right).
+
+## Environment
+
+* Operating System
+* Label merge version

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Proposed changes
+
+Describe the changes implemented in this pull request. If the changes fix a bug or resolves a feature request, be sure to link the issue. Please explain the issue and how the changes address the issue.
+
+## Types of changes
+
+What types of changes does your code introduce? Put an `x` in the boxes that apply
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionalitiy)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Other (if none of the other choices apply)
+
+## Checklist
+
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!
+
+- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
+- [ ] Changes pass the unit tests
+- [ ] Code has been run through the `poe quality` task
+- [ ] I have included necessary documentation or comments (as necessary)
+- [ ] Any dependent changes have been merged and published
+
+## Notes
+All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,29 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - kaitj
+  - tkkuehn
+  - ataha24
+  - Bradley-karat
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# assignees:
+#   - assigneeA
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
+
+template: |
+  ## Changes
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'maintenance'
+      - 'test'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+
+exclude-labels:
+  - skip_changelog
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  # major:
+  #   labels:
+  #     - 'breaking'
+  minor:
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'maintenance'
+      - 'bug'
+      - 'test'
+      - 'documentation'
+  default: patch

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,0 +1,15 @@
+name: Assign reviewer 
+
+on:
+  pull_request_target: 
+
+jobs: 
+  assign:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.assignee == null
+
+    steps:
+      - name: Assign reviewer
+        uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}" 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,69 @@
+name: Bump version
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Update changelog
+        uses: release-drafter/release-drafter@v5
+        id: release-drafter
+        with:
+          commitish: ${{ github.event.pull_request.base.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.BP_PAT_TOKEN }}
+
+      - name: Get previous version
+        nev:
+          PREV_VER: ${{ env.PREV_VER }}
+        run: |
+          if [[ "$PREV_VER" != *"-pre."* ]]; then
+            echo "OLD_BUMP=0" >> $GITHUB_ENV
+          else
+            echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
+          fi
+
+      - name: Bump version:
+        env:
+          BUMP_VER: ${{ env.OLD_BUMP }}
+        run: |
+          echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
+
+      - name: Set new release version
+        env:
+          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+        run: |
+          if [ ! -z "$RD_RELEASE" ]; then
+            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
+          else
+            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
+          fi
+
+      - name: Update version in pyproject.toml
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'pyproject.toml'
+          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: 'version = "${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}"'
+
+      - name: Commit updates
+        env:
+          SNAKEBIDS_VERSION: ${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
+          
+      - name: Push changes
+        uses: CasperWA/push-protected@v2
+        with:
+          branch: ${{ github.event.pull_request.base.ref }}
+          token: ${{ secrets.BP_PAT_TOKEN }}
+          unprotect_reviews: True


### PR DESCRIPTION
This adds actions for:
* Automatically updating pre-release versions
* Reviewer assignment.

Still need to determine how release will work before creating an action for that. I've also generated a personal access token (`BP_PAT_TOKEN`) and stored it in the repo's secrets. This token will expire in a year, and will need to be regenerated again at that time.