### PR TITLE
Add in code to search for associated dseg.tsv file

### DIFF
--- a/labelmerge/workflow/rules/label_harmonization.smk
+++ b/labelmerge/workflow/rules/label_harmonization.smk
@@ -5,6 +5,8 @@ from snakebids import bids
 checkpoint split_labels:
     input:
         labelmap=inputs["labelmap"].input_path,
+    params:
+        bids_dir=config["bids_dir"],
     output:
         binary_dir=directory(
             str(

--- a/labelmerge/workflow/scripts/label_split.py
+++ b/labelmerge/workflow/scripts/label_split.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import glob
-import os
 from pathlib import Path
 
 import nibabel as nib

--- a/labelmerge/workflow/scripts/label_split.py
+++ b/labelmerge/workflow/scripts/label_split.py
@@ -23,7 +23,7 @@ def load_metadata(atlas_path, bids_dir, smk_wildcards):
     # Walk backwards to find dseg until bids_dir is hit
     tsv_file = None
     cur_dir = atlas_path.parent
-    while cur_dir != bids_dir and tsv_file == None:
+    while cur_dir != Path(bids_dir).parent and tsv_file == None:
         # Check number of dseg files found
         dseg_files = list(glob.iglob(f"{cur_dir}/*dseg.tsv"))
         num_dsegs = len(dseg_files)


### PR DESCRIPTION
Traverses the directories backwards to find an associated dseg file. It does this by traversing backwards from where the dseg nifti file is located. To that end, this is done using a `while` loop until either a tsv file is found or until the parent of the `bids_dir` is hit. The `bids_dir` is passed through as a parameter.

As it traverses each directory, it searches for any dseg files at the current level. If a single file is found, it is assumed that this single file is associated with the dseg nifti. If multiple files are found, it currently assumes that there is also a description (`desc`) passed through. It looks for a matching `desc` as passed through the wildcards to identify the associated metadata.

If no file is found at the end of the loop, a `FileNotFoundError` is raised to note that no associated TSV file is found.

Additionally, in testing this locally, I noted that one of the test inputs was missing a label and was causing the workflow to throw an error. I've added an additional `ValueError` to be raised now if the associated label isn't found in the metadata. Alternatively, we could throw a warning and label the file with an `Unknown` desc, although we would have to be careful about how to handle multiple unknown labels.