### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "labelmerge"
 version = "0.1.0-pre.1"
 description = "Snakebids app for merging multiple label maps."
 authors = [
-    "Jason Kai <tkai@uwo.ca>, 
-    Tristan Kuehn,
-    Bradley Karat,
-    Alaa Taha,
-    Arun Thurairajah,
-    Jonathan C. Lau, 
-    Ali R. Khan"
+    "Jason Kai <tkai@uwo.ca>",
+    "Tristan Kuehn",
+    "Bradley Karat",
+    "Alaa Taha",
+    "Arun Thurairajah",
+    "Jonathan C. Lau",
+    "Ali R. Khan"
 ]
 readme = "README.md"
 


### PR DESCRIPTION
The entries in `tool.poetry.authors` weren't properly formatted strings. I should have caught this on the PR review, sorry!