### PR TITLE
Fix lowest label getting dropped

### DIFF
--- a/labelmerge/workflow/scripts/labelmerge.py
+++ b/labelmerge/workflow/scripts/labelmerge.py
@@ -45,7 +45,7 @@ def merge_labels(base_ds, overlay_ds):
     overall_idx = 0
     for dataset in [base_ds, overlay_ds]:
         for name, arr in dataset.items():
-            out_arr[arr] = overall_idx
+            out_arr[arr] = overall_idx + 1
             out_labels[overall_idx] = overall_idx + 1
             out_names[overall_idx] = name
             overall_idx += 1


### PR DESCRIPTION
The first label to be handled was set to zero, effectively dropping it, and all the labels were off by one. This should fix the problem.