### PR TITLE
Add exclusions for base and overlay images

### DIFF
--- a/labelmerge/config/snakebids.yml
+++ b/labelmerge/config/snakebids.yml
@@ -79,6 +79,12 @@ parse_args:
   --overlay_desc:
     help: Description entity for overlay labelmaps
     nargs: '?'
+  --base_exceptions:
+    help: Space separated integer labels from the base labelmap to keep over overlay labels at the same voxels.
+    nargs: '*'
+  --overlay_exceptions:
+    help: Space separated integer labels from the overlay image to discard.
+    nargs: '*'
 
 # Workflow specific config
 

--- a/labelmerge/workflow/rules/label_harmonization.smk
+++ b/labelmerge/workflow/rules/label_harmonization.smk
@@ -76,9 +76,13 @@ rule merge_labels:
             desc="combined",
             **base_inputs["labelmap"].input_wildcards,
         ),
+    params:
+        base_exceptions=f"--base_exceptions {' '.join(config['base_exceptions'])}" if config.get("base_exceptions") else "",
+        overlay_exceptions=f"--overlay_exceptions {' '.join(config['overlay_exceptions'])}" if config.get("overlay_exceptions") else "",
     resources:
         script=str(Path(workflow.basedir) / "scripts" / "labelmerge.py"),
     shell:
         "python3 {resources.script} {input.base_map} {input.base_metadata} "
         "{input.overlay_map} {input.overlay_metadata} "
-        "{output.merged_map} {output.merged_metadata}"
+        "{output.merged_map} {output.merged_metadata} "
+        "{params.base_exceptions} {params.overlay_exceptions}"

--- a/labelmerge/workflow/scripts/labelmerge.py
+++ b/labelmerge/workflow/scripts/labelmerge.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
+from __future__ import annotations
 from argparse import ArgumentParser
+from os import PathLike
 from pathlib import Path
 
 import nibabel as nib
 import numpy as np
+from numpy.typing import ArrayLike
 import pandas as pd
 import xarray as xr
 
 
-def load_atlas(atlas_path):
+def load_atlas(atlas_path: PathLike):
     """Loading relevant atlas data"""
     atlas = nib.load(atlas_path)
     data = atlas.get_fdata().astype(np.ushort)
@@ -22,9 +25,14 @@ class MetadataError(Exception):
     """Error raised when there's an issue with the metadata."""
 
 
-def assemble_mask(atlas, metadata, label, prefix=""):
+def assemble_mask(
+    atlas: ArrayLike,
+    metadata: pd.DataFrame,
+    label: int,
+    prefix: str = "",
+):
     try:
-        name = metadata[metadata["index"] == label].name.iloc[0]
+        name: str = metadata[metadata["index"] == label].name.iloc[0]
     except IndexError as err:
         raise MetadataError(
             f"Label with index {label} from {prefix}atlas not found in metadata table."
@@ -35,34 +43,73 @@ def assemble_mask(atlas, metadata, label, prefix=""):
     )
 
 
-def split_labels(atlas, metadata, prefix=""):
-    return xr.Dataset(
+def split_labels(
+    atlas: np.ndarray,
+    metadata: pd.DataFrame,
+    prefix: str = "",
+    exceptions: list[str] = [],
+) -> list[xr.Dataset]:
+    unique_vals = np.unique(atlas[atlas > 0])
+    normal_ds = xr.Dataset(
         dict(
             [
                 assemble_mask(atlas, metadata, label, prefix)
-                for label in np.unique(atlas[atlas > 0])
+                for label in unique_vals
+                if label not in exceptions
             ]
         )
     )
+    if not exceptions:
+        return [normal_ds]
+    exception_ds = xr.Dataset(
+        dict(
+            [
+                assemble_mask(atlas, metadata, label, prefix)
+                for label in unique_vals
+                if label in exceptions
+            ]
+        )
+    )
+    return [normal_ds, exception_ds]
 
 
-def merge_labels(base_ds, overlay_ds):
-    out_arr = np.zeros(list(dim for dim in base_ds.dims.values()), dtype=np.int_)
-    out_labels = list(range(len(base_ds) + len(overlay_ds)))
-    out_names = out_labels.copy()
+def merge_labels(datasets: list[xr.Dataset]):
+    """Merge several labelmaps into one output labelmap with metadata.
+
+    Parameters
+    ----------
+    datasets: list of Dataset
+        A list of datasets where each variable name is a label name and each
+        DataArray is the corresponding mask. Earlier entries in the list of
+        datasets are overwritten by later entries.
+
+    Returns
+    -------
+    ndarray
+        A 3D labelmap with the merged label data.
+    DataFrame
+        The metadata table containing label names.
+    """
+    out_arr: np.ndarray = np.zeros(
+        list(dim for dim in datasets[0].dims.values()), dtype=np.int_
+    )
+    out_labels = [
+        idx + 1 for idx in range(sum(len(dataset) for dataset in datasets))
+    ]
+    out_names = ["" for _ in out_labels]
 
     overall_idx = 0
-    for dataset in [base_ds, overlay_ds]:
+    for dataset in datasets:
         for name, arr in dataset.items():
             out_arr[arr] = int(overall_idx + 1)
-            out_labels[overall_idx] = int(overall_idx + 1)
             out_names[overall_idx] = name
             overall_idx += 1
     out_metadata = pd.DataFrame({"index": out_labels, "name": out_names})
     return out_arr, out_metadata
 
 
-def gen_parser():
+def gen_parser() -> ArgumentParser:
+    """Generate the CLI parser for this script."""
     parser = ArgumentParser()
     parser.add_argument("base_map")
     parser.add_argument("base_metadata")
@@ -70,6 +117,23 @@ def gen_parser():
     parser.add_argument("overlay_metadata")
     parser.add_argument("out_map_path")
     parser.add_argument("out_metadata_path")
+    parser.add_argument(
+        "--base_exceptions",
+        nargs="*",
+        help=(
+            "Space separated list of integer labels from the base image to keep over "
+            "overlay labels at the same voxels."
+        ),
+        type=int,
+    )
+    parser.add_argument(
+        "--overlay_exceptions",
+        nargs="*",
+        help=(
+            "Space separated list of integer labels from the overlay image to discard."
+        ),
+        type=int,
+    )
     return parser
 
 
@@ -80,11 +144,24 @@ def main():
     base_metadata = pd.read_csv(args.base_metadata, sep="\t")
     overlay_data, _, _ = load_atlas(Path(args.overlay_map))
     overlay_metadata = pd.read_csv(args.overlay_metadata, sep="\t")
-    base_ds = split_labels(base_data, base_metadata, prefix="base ")
-    overlay_ds = split_labels(
-        overlay_data, overlay_metadata, prefix="overlay "
+    base_exceptions = args.base_exceptions if args.base_exceptions else []
+    overlay_exceptions = args.overlay_exceptions if args.overlay_exceptions else []
+    base_datasets = split_labels(
+        base_data,
+        base_metadata,
+        prefix="base ",
+        exceptions=base_exceptions,
     )
-    merged_map, merged_metadata = merge_labels(base_ds, overlay_ds)
+    overlay_datasets = split_labels(
+        overlay_data,
+        overlay_metadata,
+        prefix="overlay ",
+        exceptions=overlay_exceptions,
+    )
+    # Note that overlay exceptions are ignored
+    merged_map, merged_metadata = merge_labels(
+        base_datasets[0:1] + overlay_datasets[0:1] + base_datasets[1:]
+    )
     merged_img = nib.Nifti1Image(
         dataobj=merged_map, affine=base_affine, header=base_header
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -546,6 +546,25 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "mypy"
+version = "0.991"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -1368,7 +1387,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "3b0d6cd5b8f8ab7e5609b57380347a1f66ceffaa3f7aa9ae4d482cc2855d0510"
+content-hash = "9e7bbf5b88d7723cca018eea9d5bb32749de05125bf4febbd726b207e6687f65"
 
 [metadata.files]
 appdirs = [
@@ -1651,6 +1670,38 @@ mock = [
 more-itertools = [
     {file = "more-itertools-9.0.0.tar.gz", hash = "sha256:5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab"},
     {file = "more_itertools-9.0.0-py3-none-any.whl", hash = "sha256:250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41"},
+]
+mypy = [
+    {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
+    {file = "mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d"},
+    {file = "mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6"},
+    {file = "mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb"},
+    {file = "mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305"},
+    {file = "mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c"},
+    {file = "mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372"},
+    {file = "mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f"},
+    {file = "mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33"},
+    {file = "mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05"},
+    {file = "mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad"},
+    {file = "mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297"},
+    {file = "mypy-0.991-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813"},
+    {file = "mypy-0.991-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711"},
+    {file = "mypy-0.991-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd"},
+    {file = "mypy-0.991-cp37-cp37m-win_amd64.whl", hash = "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"},
+    {file = "mypy-0.991-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a"},
+    {file = "mypy-0.991-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93"},
+    {file = "mypy-0.991-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf"},
+    {file = "mypy-0.991-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135"},
+    {file = "mypy-0.991-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70"},
+    {file = "mypy-0.991-cp38-cp38-win_amd64.whl", hash = "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243"},
+    {file = "mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d"},
+    {file = "mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5"},
+    {file = "mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3"},
+    {file = "mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648"},
+    {file = "mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476"},
+    {file = "mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461"},
+    {file = "mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb"},
+    {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ poethepoet = "^0.13.1"
 pre-commit = "^2.17.0"
 snakefmt = "^0.6.1"
 yamlfix = "^1.1.0"
+mypy = "^0.991"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Proposed changes

Add "exclusion" support, allowing overlay labels to be dropped and base labels to be kept even in the presence of overlay labels.

Note: This just drops overlay exclusions -- we may want to consider instead keeping excluded overlay labels if there's no base label to overwrite them, and adding a separate mechanism to drop labels from base or overlay label maps.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)
