### PR TITLE
Add setting to allow labels to be dropped from input maps

### DIFF
--- a/labelmerge/config/snakebids.yml
+++ b/labelmerge/config/snakebids.yml
@@ -80,7 +80,13 @@ parse_args:
     help: Space separated integer labels from the base labelmap to keep over overlay labels at the same voxels.
     nargs: '*'
   --overlay_exceptions:
-    help: Space separated integer labels from the overlay image to discard.
+    help: Space separated integer labels from the overlay image to be overwritten by base labels at the same voxels.
+    nargs: '*'
+  --base_drops:
+    help: Space separated integer labels from the base image to drop from the output.
+    nargs: '*'
+  --overlay_drops:
+    help: Space separated integer labels from the overlay image to drop from the output.
     nargs: '*'
 
 # Workflow specific config

--- a/labelmerge/workflow/rules/label_harmonization.smk
+++ b/labelmerge/workflow/rules/label_harmonization.smk
@@ -83,10 +83,17 @@ rule merge_labels:
         overlay_exceptions=f"--overlay_exceptions {' '.join(config['overlay_exceptions'])}"
         if config.get("overlay_exceptions")
         else "",
+        base_drops=f"--base_drops {' '.join(config['base_drops'])}"
+        if config.get("base_drops")
+        else "",
+        overlay_drops=f"--overlay_drops {' '.join(config['overlay_drops'])}"
+        if config.get("overlay_drops")
+        else "",
     resources:
         script=str(Path(workflow.basedir) / "scripts" / "labelmerge.py"),
     shell:
         "python3 {resources.script} {input.base_map} {input.base_metadata} "
         "{input.overlay_map} {input.overlay_metadata} "
         "{output.merged_map} {output.merged_metadata} "
-        "{params.base_exceptions} {params.overlay_exceptions}"
+        "{params.base_exceptions} {params.overlay_exceptions} "
+        "{params.base_drops} {params.overlay_drops}"


### PR DESCRIPTION
## Proposed changes

Overlay exceptions' behaviour was kind of ambiguous, so this clarifies it and adds the option to drop labels from either input map. Now overlay exceptions are overwritten by base labels, base exceptions overwrite everything else, and base/overlay drops are just removed entirely.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through the `poe quality` task
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
