### PR TITLE
Fix bump_version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -20,8 +20,12 @@ jobs:
           commitish: ${{ github.event.pull_request.base.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.BP_PAT_TOKEN }}
+          
+      - name: Get previous release version
+        run: |
+          echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
 
-      - name: Get previous version
+      - name: Get previous bump version
         env:
           PREV_VER: ${{ env.PREV_VER }}
         run: |


### PR DESCRIPTION
## Proposed changes

Adds in a missing step to the workflow, grabbing the previous release version. Not having this was causing the workflow to improperly bump the version (e.g. always bumping to `x-pre.1`.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through the `poe quality` task
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
