### PR TITLE
use PAT token instead of github token in publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           name: ${{ env.NEW_RELEASE }}
           tag: v${{ env.NEW_RELEASE }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BP_PAT_TOKEN }}
 
   # deploy_pypi:
   #   name: PyPI Deploy


### PR DESCRIPTION
## Proposed changes

Docker deploy workflow wasn't triggering. Switching to use PAT token should fix it.

Relevant link: https://stackoverflow.com/questions/69063452/github-actions-on-release-created-workflow-trigger-not-working

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through the `poe quality` task
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
